### PR TITLE
Pipeline/update action version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Use maker cachix
-      uses: cachix/cachix-action@v13
+      uses: cachix/cachix-action@v12
       with:
         name: maker
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -16,7 +16,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Use maker cachix
-      uses: cachix/cachix-action@v10
+      uses: cachix/cachix-action@v12
       with:
         name: maker
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Use maker cachix
-      uses: cachix/cachix-action@v10
+      uses: cachix/cachix-action@v13
       with:
         name: maker
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,13 +10,13 @@ jobs:
         submodules: recursive
 
     - name: Install nix 2.3.6
-      uses: cachix/install-nix-action@v13
+      uses: cachix/install-nix-action@v19
       with:
         install_url: https://releases.nixos.org/nix/nix-2.3.6/install
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Use maker cachix
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@v10
       with:
         name: maker
 


### PR DESCRIPTION
Since node12 is deprecated we need to update the github action that uses it. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

@gbalabasquer It looks like the code is broken https://github.com/makerdao/dss-chain-log/actions/runs/4431255240/jobs/7773995017 

But I've pushed the right version into this branch. Feel free to include the action version update code into your code fix when it requires.

cc @eskp @sanbotto @OleksandrUA @cristidas @jeannettemcd @zdumitru